### PR TITLE
New fennel-wf binary.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/main.rs"
 name = "fennel-ipfs"
 path = "src/ipfs/main.rs"
 
+[[bin]]
+name = "fennel-wf"
+path = "src/wf/main.rs"
+
 [dependencies]
 clap = { version = "3.0.10", features = ["derive"] }
 

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -60,17 +60,4 @@ pub enum Commands {
     /// Runs a WebSocket RPC exposing crypto functions to parallel applications
     #[clap()]
     StartRPC {},
-
-    /* Whiteflag */
-    #[clap(setting(AppSettings::ArgRequiredElseHelp))]
-    Encode { json: String },
-
-    #[clap(setting(AppSettings::ArgRequiredElseHelp))]
-    Decode { hex: String },
-
-    #[clap()]
-    Auth { logout: bool },
-
-    #[clap()]
-    Message { code: String },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,20 +89,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             println!("Starting RPC on localhost:9030");
             start_rpc().await?;
         }
-
-        Commands::Encode { json } => {
-            println!("{}", wf_cli::WhiteflagCLICommands::encode(json)?);
-        }
-        Commands::Decode { hex } => {
-            println!("{}", wf_cli::WhiteflagCLICommands::decode(hex)?);
-        }
-        Commands::Auth { logout } => {
-            println!("{}", wf_cli::WhiteflagCLICommands::auth(logout.clone())?);
-        }
-        Commands::Message { code } => {
-            let message = wf_cli::WhiteflagCLICommands::message(code.to_owned())?;
-            println!("{}", message);
-        }
     }
 
     Ok(())

--- a/src/wf/command.rs
+++ b/src/wf/command.rs
@@ -1,0 +1,24 @@
+use clap::{AppSettings, Parser, Subcommand};
+
+#[derive(Parser)]
+#[clap(name = "fennel-wf")]
+#[clap(about = "A tool for managing Whiteflag messages", long_about = None)]
+pub struct Cli {
+    #[clap(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    #[clap(setting(AppSettings::ArgRequiredElseHelp))]
+    Encode { json: String },
+
+    #[clap(setting(AppSettings::ArgRequiredElseHelp))]
+    Decode { hex: String },
+
+    #[clap()]
+    Auth { logout: bool },
+
+    #[clap()]
+    Message { code: String },
+}

--- a/src/wf/main.rs
+++ b/src/wf/main.rs
@@ -1,0 +1,24 @@
+
+use clap::Parser;
+mod command;
+use command::{Cli, Commands};
+
+pub fn main() {
+    let args = Cli::parse();
+
+    match &args.command {
+        Commands::Encode { json } => {
+            println!("{}", wf_cli::WhiteflagCLICommands::encode(json).unwrap());
+        }
+        Commands::Decode { hex } => {
+            println!("{}", wf_cli::WhiteflagCLICommands::decode(hex).unwrap());
+        }
+        Commands::Auth { logout } => {
+            println!("{}", wf_cli::WhiteflagCLICommands::auth(logout.clone()).unwrap());
+        }
+        Commands::Message { code } => {
+            let message = wf_cli::WhiteflagCLICommands::message(code.to_owned()).unwrap();
+            println!("{}", message);
+        }
+    }
+}

--- a/src/wf/main.rs
+++ b/src/wf/main.rs
@@ -1,4 +1,3 @@
-
 use clap::Parser;
 mod command;
 use command::{Cli, Commands};
@@ -14,7 +13,10 @@ pub fn main() {
             println!("{}", wf_cli::WhiteflagCLICommands::decode(hex).unwrap());
         }
         Commands::Auth { logout } => {
-            println!("{}", wf_cli::WhiteflagCLICommands::auth(logout.clone()).unwrap());
+            println!(
+                "{}",
+                wf_cli::WhiteflagCLICommands::auth(logout.clone()).unwrap()
+            );
         }
         Commands::Message { code } => {
             let message = wf_cli::WhiteflagCLICommands::message(code.to_owned()).unwrap();


### PR DESCRIPTION
@isaacadams you can run this through `cargo run --bin fennel-wf -- <args>` and it exposes all of the Whiteflag functions without the tokio error.